### PR TITLE
fix live chat / freenode link

### DIFF
--- a/templates/gamethread.txt
+++ b/templates/gamethread.txt
@@ -2,7 +2,7 @@
 
 **TIME**     |**MEDIA**                            |**LOCATION**        |**MISC**
 :------------|:------------------------------------|:-------------------|:-------------------------
- Eastern |**TV**:                        |                | [Live chat](https://webchat.freenode.net/?channels=r/NBA&uio=MTE9MjQ255/)
+ Eastern |**TV**:                        |                | [Live chat](https://webchat.freenode.net/?channels=reddit-nba&uio=MTE9MjQ255/)
  Central |**Streaming**: N/A | **Team Subreddits**|
  Mountain|**Game Story**: [NBA.com]({{ nba_url }}#nbaGIlive)| [/r/{{ away.subreddit }}](https://reddit.com/r/{{ away.subreddit }})          |
  Pacific |**Box Score**: [NBA.com]({{ nba_url }}#nbaGIboxscore) | [/r/{{ home.subreddit }}](https://reddit.com/r/{{ home.subreddit }})          |


### PR DESCRIPTION
provides correct url/channel for the freenode IRC chatroom (the channel migrated from #reddit-nba to ##reddit-nba awhile ago to conform to freenode channel naming policies)